### PR TITLE
Display automatically new Topics

### DIFF
--- a/app/src/main/java/com/github/se/studybuddies/database/DatabaseConnection.kt
+++ b/app/src/main/java/com/github/se/studybuddies/database/DatabaseConnection.kt
@@ -29,6 +29,7 @@ import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.FirebaseStorage
+import java.util.UUID
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
@@ -37,7 +38,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
-import java.util.UUID
 
 class DatabaseConnection {
 

--- a/app/src/main/java/com/github/se/studybuddies/ui/groups/GroupScreen.kt
+++ b/app/src/main/java/com/github/se/studybuddies/ui/groups/GroupScreen.kt
@@ -22,13 +22,13 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Button
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
@@ -63,7 +63,6 @@ import com.github.se.studybuddies.viewModels.ChatViewModel
 import com.github.se.studybuddies.viewModels.GroupViewModel
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GroupScreen(
     groupUID: String,
@@ -72,20 +71,17 @@ fun GroupScreen(
     navigationActions: NavigationActions
 ) {
   val group by groupViewModel.group.observeAsState()
-  val topics by groupViewModel.topics.observeAsState()
+  val topics by groupViewModel.topics.collectAsState()
 
   val nameState = remember { mutableStateOf(group?.name ?: "") }
   val pictureState = remember { mutableStateOf(group?.picture ?: Uri.EMPTY) }
   val membersState = remember { mutableStateOf(group?.members ?: emptyList()) }
-  val topicList = remember { mutableStateOf(topics?.getAllTopics() ?: emptyList()) }
 
   group?.let {
     nameState.value = it.name
     pictureState.value = it.picture
     membersState.value = it.members
   }
-
-  topics?.let { topicList.value = it.getAllTopics() }
 
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag("GroupScreen"),
@@ -175,9 +171,9 @@ fun GroupScreen(
               modifier = Modifier.fillMaxSize(),
               verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.Top),
               horizontalAlignment = Alignment.Start,
-              content = {
-                items(topicList.value) { topic -> TopicItem(groupUID, topic, navigationActions) }
-              })
+          ) {
+            items(topics.getAllTopics()) { topic -> TopicItem(groupUID, topic, navigationActions) }
+          }
         }
       }
 }

--- a/app/src/main/java/com/github/se/studybuddies/viewModels/GroupViewModel.kt
+++ b/app/src/main/java/com/github/se/studybuddies/viewModels/GroupViewModel.kt
@@ -11,6 +11,8 @@ import com.github.se.studybuddies.data.TopicList
 import com.github.se.studybuddies.data.User
 import com.github.se.studybuddies.database.DatabaseConnection
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -20,14 +22,14 @@ class GroupViewModel(uid: String? = null) : ViewModel() {
   private val _members = MutableLiveData<List<User>>(emptyList())
   val members: LiveData<List<User>> = _members
   val group: LiveData<Group> = _group
-  private val _topics = MutableLiveData(TopicList(emptyList()))
-  val topics: LiveData<TopicList> = _topics
+  private val _topics = MutableStateFlow(TopicList(emptyList()))
+  val topics = _topics.asStateFlow()
 
   init {
     if (uid != null) {
       fetchGroupData(uid)
       fetchUsers()
-      fetchTopics(uid)
+      subscribeToTopics(uid)
     }
   }
 
@@ -35,14 +37,9 @@ class GroupViewModel(uid: String? = null) : ViewModel() {
     viewModelScope.launch { _group.value = db.getGroup(uid) }
   }
 
-  fun fetchTopics(uid: String) {
-    viewModelScope.launch {
-      try {
-        val topics = db.getALlTopics(uid)
-        _topics.value = topics
-      } catch (e: Exception) {
-        Log.d("MyPrint", "In ViewModel, could not fetch topics with error ", e)
-      }
+  private fun subscribeToTopics(uid: String) {
+    db.getAllTopics(uid, viewModelScope, Dispatchers.IO, Dispatchers.Main) { topicList ->
+      _topics.value = topicList
     }
   }
 


### PR DESCRIPTION
I fix in the group screen the issue where new topics weren't automatically displayed if we weren't reloading the page.
So when we add a new topics, it's now displayed.
It's also displaying the new topic if it's someone else that add it and we are already on the groupScreen