### PR TITLE
Group members

### DIFF
--- a/app/src/main/java/com/github/se/studybuddies/MainActivity.kt
+++ b/app/src/main/java/com/github/se/studybuddies/MainActivity.kt
@@ -32,6 +32,7 @@ import com.github.se.studybuddies.ui.calender.DailyPlannerScreen
 import com.github.se.studybuddies.ui.chat.ChatScreen
 import com.github.se.studybuddies.ui.chat.DirectMessageScreen
 import com.github.se.studybuddies.ui.groups.CreateGroup
+import com.github.se.studybuddies.ui.groups.GroupMembers
 import com.github.se.studybuddies.ui.groups.GroupScreen
 import com.github.se.studybuddies.ui.groups.GroupSetting
 import com.github.se.studybuddies.ui.groups.GroupsHome
@@ -236,6 +237,17 @@ class MainActivity : ComponentActivity() {
                     Log.d("MyPrint", "Successfully navigated to GroupSetting")
                   }
                 }
+              composable(
+                  route = "${Route.GROUPMEMBERS}/{groupUID}",
+                  arguments = listOf(navArgument("groupUID") { type = NavType.StringType })) {
+                      backStackEntry ->
+                  val groupUID = backStackEntry.arguments?.getString("groupUID")
+                  ifNotNull(groupUID) { groupUID ->
+                      val groupViewModel = remember { GroupViewModel(groupUID, db) }
+                      GroupMembers(groupUID, groupViewModel, navigationActions, db)
+                      Log.d("MyPrint", "Successfully navigated to GroupMembers")
+                  }
+              }
             composable(Route.CHAT) {
               val chat = remember { chatViewModel.getChat() ?: Chat.empty() }
               val messageViewModel = remember { MessageViewModel(chat) }

--- a/app/src/main/java/com/github/se/studybuddies/MainActivity.kt
+++ b/app/src/main/java/com/github/se/studybuddies/MainActivity.kt
@@ -150,9 +150,9 @@ class MainActivity : ComponentActivity() {
                 arguments = listOf(navArgument("groupUID") { type = NavType.StringType })) {
                     backStackEntry ->
                   val groupUID = backStackEntry.arguments?.getString("groupUID")
-                  ifNotNull(groupUID) { groupUID ->
+                  ifNotNull(groupUID) { groupUid ->
                     val groupViewModel = remember { GroupViewModel(groupUID, db) }
-                    GroupScreen(groupUID, groupViewModel, chatViewModel, navigationActions, db)
+                    GroupScreen(groupUid, groupViewModel, chatViewModel, navigationActions, db)
                     Log.d("MyPrint", "Successfully navigated to GroupScreen")
                   }
                 }
@@ -161,8 +161,8 @@ class MainActivity : ComponentActivity() {
                 arguments = listOf(navArgument("backRoute") { type = NavType.StringType })) {
                     backStackEntry ->
                   val backRoute = backStackEntry.arguments?.getString("backRoute")
-                  ifNotNull(backRoute) { backRoute ->
-                    Settings(backRoute, navigationActions)
+                  ifNotNull(backRoute) {
+                    Settings(it, navigationActions)
                     Log.d("MyPrint", "Successfully navigated to Settings")
                   }
                 }
@@ -231,9 +231,9 @@ class MainActivity : ComponentActivity() {
                 arguments = listOf(navArgument("groupUID") { type = NavType.StringType })) {
                     backStackEntry ->
                   val groupUID = backStackEntry.arguments?.getString("groupUID")
-                  ifNotNull(groupUID) { groupUID ->
+                  ifNotNull(groupUID) { groupUid ->
                     val groupViewModel = remember { GroupViewModel(groupUID, db) }
-                    GroupSetting(groupUID, groupViewModel, navigationActions, db)
+                    GroupSetting(groupUid, groupViewModel, navigationActions, db)
                     Log.d("MyPrint", "Successfully navigated to GroupSetting")
                   }
                 }
@@ -242,9 +242,9 @@ class MainActivity : ComponentActivity() {
                 arguments = listOf(navArgument("groupUID") { type = NavType.StringType })) {
                     backStackEntry ->
                   val groupUID = backStackEntry.arguments?.getString("groupUID")
-                  ifNotNull(groupUID) { groupUID ->
+                  ifNotNull(groupUID) { groupUid ->
                     val groupViewModel = remember { GroupViewModel(groupUID, db) }
-                    GroupMembers(groupUID, groupViewModel, navigationActions, db)
+                    GroupMembers(groupUid, groupViewModel, navigationActions, db)
                     Log.d("MyPrint", "Successfully navigated to GroupMembers")
                   }
                 }
@@ -345,9 +345,9 @@ class MainActivity : ComponentActivity() {
                 arguments = listOf(navArgument("groupUID") { type = NavType.StringType })) {
                     backStackEntry ->
                   val groupUID = backStackEntry.arguments?.getString("groupUID")
-                  ifNotNull(groupUID) { groupUID ->
-                    val viewModel2 = remember { SharedTimerViewModel(groupUID, db) }
-                    SharedTimerScreen(navigationActions, viewModel2, groupUID)
+                  ifNotNull(groupUID) { groupUid ->
+                    val viewModel2 = remember { SharedTimerViewModel(groupUid, db) }
+                    SharedTimerScreen(navigationActions, viewModel2, groupUid)
                     Log.d("MyPrint", "Successfully navigated to SharedTimer")
                   }
                 }

--- a/app/src/main/java/com/github/se/studybuddies/MainActivity.kt
+++ b/app/src/main/java/com/github/se/studybuddies/MainActivity.kt
@@ -237,17 +237,17 @@ class MainActivity : ComponentActivity() {
                     Log.d("MyPrint", "Successfully navigated to GroupSetting")
                   }
                 }
-              composable(
-                  route = "${Route.GROUPMEMBERS}/{groupUID}",
-                  arguments = listOf(navArgument("groupUID") { type = NavType.StringType })) {
-                      backStackEntry ->
+            composable(
+                route = "${Route.GROUPMEMBERS}/{groupUID}",
+                arguments = listOf(navArgument("groupUID") { type = NavType.StringType })) {
+                    backStackEntry ->
                   val groupUID = backStackEntry.arguments?.getString("groupUID")
                   ifNotNull(groupUID) { groupUID ->
-                      val groupViewModel = remember { GroupViewModel(groupUID, db) }
-                      GroupMembers(groupUID, groupViewModel, navigationActions, db)
-                      Log.d("MyPrint", "Successfully navigated to GroupMembers")
+                    val groupViewModel = remember { GroupViewModel(groupUID, db) }
+                    GroupMembers(groupUID, groupViewModel, navigationActions, db)
+                    Log.d("MyPrint", "Successfully navigated to GroupMembers")
                   }
-              }
+                }
             composable(Route.CHAT) {
               val chat = remember { chatViewModel.getChat() ?: Chat.empty() }
               val messageViewModel = remember { MessageViewModel(chat) }

--- a/app/src/main/java/com/github/se/studybuddies/navigation/Destinations.kt
+++ b/app/src/main/java/com/github/se/studybuddies/navigation/Destinations.kt
@@ -12,6 +12,7 @@ val SETTINGS_DESTINATIONS =
 val GROUPS_SETTINGS_DESTINATIONS =
     listOf(
         Destination(route = Route.GROUPSETTING, textId = "Modify group"),
+        Destination(route = Route.GROUPMEMBERS, textId = "Members"),
         Destination(route = Route.LEAVEGROUP, textId = "Leave group"),
         Destination(route = Route.DELETEGROUP, textId = "Delete group"))
 

--- a/app/src/main/java/com/github/se/studybuddies/navigation/Destinations.kt
+++ b/app/src/main/java/com/github/se/studybuddies/navigation/Destinations.kt
@@ -17,8 +17,7 @@ val GROUPS_SETTINGS_DESTINATIONS =
         Destination(route = Route.DELETEGROUP, textId = "Delete group"))
 
 val GROUPS_MEMBERS_DESTINATIONS =
-    listOf(
-        Destination(route = Route.USERREMOVE, textId = "Remove user"))
+    listOf(Destination(route = Route.USERREMOVE, textId = "Remove user"))
 
 val BOTTOM_NAVIGATION_DESTINATIONS =
     listOf(

--- a/app/src/main/java/com/github/se/studybuddies/navigation/Destinations.kt
+++ b/app/src/main/java/com/github/se/studybuddies/navigation/Destinations.kt
@@ -16,6 +16,10 @@ val GROUPS_SETTINGS_DESTINATIONS =
         Destination(route = Route.LEAVEGROUP, textId = "Leave group"),
         Destination(route = Route.DELETEGROUP, textId = "Delete group"))
 
+val GROUPS_MEMBERS_DESTINATIONS =
+    listOf(
+        Destination(route = Route.USERREMOVE, textId = "Remove user"))
+
 val BOTTOM_NAVIGATION_DESTINATIONS =
     listOf(
         Destination(route = Route.SOLOSTUDYHOME, icon = R.drawable.user_v2, textId = "Solo study"),

--- a/app/src/main/java/com/github/se/studybuddies/navigation/Route.kt
+++ b/app/src/main/java/com/github/se/studybuddies/navigation/Route.kt
@@ -6,6 +6,7 @@ object Route {
   const val GROUPSHOME = "GroupsHome"
   const val CREATEGROUP = "CreateGroup"
   const val DELETEGROUP = "DeleteGroup"
+  const val USERREMOVE = "RemoveUser"
   const val GROUPSETTING = "GroupSetting"
   const val LEAVEGROUP = "LeaveGroup"
   const val GROUPMEMBERS = "GroupMembers"

--- a/app/src/main/java/com/github/se/studybuddies/navigation/Route.kt
+++ b/app/src/main/java/com/github/se/studybuddies/navigation/Route.kt
@@ -8,6 +8,7 @@ object Route {
   const val DELETEGROUP = "DeleteGroup"
   const val GROUPSETTING = "GroupSetting"
   const val LEAVEGROUP = "LeaveGroup"
+  const val GROUPMEMBERS = "GroupMembers"
   const val GROUP = "Group"
   const val CALENDAR = "Calendar"
   const val SETTINGS = "Settings"

--- a/app/src/main/java/com/github/se/studybuddies/ui/groups/GroupMembers.kt
+++ b/app/src/main/java/com/github/se/studybuddies/ui/groups/GroupMembers.kt
@@ -1,0 +1,89 @@
+package com.github.se.studybuddies.ui.groups
+
+import android.annotation.SuppressLint
+import android.net.Uri
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.github.se.studybuddies.R
+import com.github.se.studybuddies.database.DbRepository
+import com.github.se.studybuddies.navigation.NavigationActions
+import com.github.se.studybuddies.navigation.Route
+import com.github.se.studybuddies.permissions.checkPermission
+import com.github.se.studybuddies.permissions.imagePermissionVersion
+import com.github.se.studybuddies.ui.shared_elements.GoBackRouteButton
+import com.github.se.studybuddies.ui.shared_elements.SaveButton
+import com.github.se.studybuddies.ui.shared_elements.Sub_title
+import com.github.se.studybuddies.ui.shared_elements.TopNavigationBar
+import com.github.se.studybuddies.ui.theme.White
+import com.github.se.studybuddies.viewModels.GroupViewModel
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun GroupMembers(
+    groupUID: String,
+    groupViewModel: GroupViewModel,
+    navigationActions: NavigationActions,
+    db: DbRepository
+) {
+
+    if (groupUID.isEmpty()) return
+    groupViewModel.fetchGroupData(groupUID)
+    val groupData by groupViewModel.group.observeAsState()
+
+    val nameState = remember { mutableStateOf(groupData?.name ?: "") }
+    val members = remember { mutableStateOf (???) }
+
+    val context = LocalContext.current
+
+    groupData?.let {
+        nameState.value = it.name
+        members.value = ???
+    }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize().background(White).testTag("members_scaffold"),
+        topBar = {
+            TopNavigationBar(
+                title = { Sub_title("Members") },
+                navigationIcon = {
+                    GoBackRouteButton(navigationActions = navigationActions, Route.GROUPSHOME)
+                },
+                actions = { GroupsSettingsButton(groupUID, navigationActions, db) })
+        }) { paddingValues ->
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.Start,
+            verticalArrangement = Arrangement.Top) {
+            LazyColumn(
+                modifier =
+                Modifier.fillMaxSize().padding(paddingValues).testTag("draw_member_column"),
+                verticalArrangement = Arrangement.spacedBy(5.dp, Alignment.Top),
+                horizontalAlignment = Alignment.CenterHorizontally) {
+                item { Spacer(modifier = Modifier.padding(10.dp)) }
+                item { Name(nameState) }
+                item { Spacer(modifier = Modifier.padding(10.dp)) }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/se/studybuddies/ui/groups/GroupMembers.kt
+++ b/app/src/main/java/com/github/se/studybuddies/ui/groups/GroupMembers.kt
@@ -1,14 +1,8 @@
 package com.github.se.studybuddies.ui.groups
 
 import android.annotation.SuppressLint
-import android.net.Uri
-import android.os.Build
-import android.util.Log
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -30,22 +24,16 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -54,7 +42,6 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -64,27 +51,17 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import coil.compose.rememberImagePainter
 import com.github.se.studybuddies.R
-import com.github.se.studybuddies.data.Group
 import com.github.se.studybuddies.data.User
 import com.github.se.studybuddies.database.DbRepository
 import com.github.se.studybuddies.navigation.GROUPS_MEMBERS_DESTINATIONS
-import com.github.se.studybuddies.navigation.GROUPS_SETTINGS_DESTINATIONS
 import com.github.se.studybuddies.navigation.NavigationActions
 import com.github.se.studybuddies.navigation.Route
-import com.github.se.studybuddies.permissions.checkPermission
-import com.github.se.studybuddies.permissions.imagePermissionVersion
 import com.github.se.studybuddies.ui.shared_elements.GoBackRouteButton
-import com.github.se.studybuddies.ui.shared_elements.MainScreenScaffold
-import com.github.se.studybuddies.ui.shared_elements.SaveButton
-import com.github.se.studybuddies.ui.shared_elements.SearchIcon
 import com.github.se.studybuddies.ui.shared_elements.Sub_title
 import com.github.se.studybuddies.ui.shared_elements.TopNavigationBar
 import com.github.se.studybuddies.ui.theme.Blue
 import com.github.se.studybuddies.ui.theme.White
 import com.github.se.studybuddies.viewModels.GroupViewModel
-import com.github.se.studybuddies.viewModels.GroupsHomeViewModel
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter", "MutableCollectionMutableState")
 @Composable
@@ -95,206 +72,199 @@ fun GroupMembers(
     db: DbRepository
 ) {
 
-    if (groupUID.isEmpty()) return
-    groupViewModel.fetchGroupData(groupUID)
-    val groupData by groupViewModel.group.observeAsState()
+  if (groupUID.isEmpty()) return
+  groupViewModel.fetchGroupData(groupUID)
+  val groupData by groupViewModel.group.observeAsState()
 
-    val nameState = remember { mutableStateOf(groupData?.name ?: "") }
-    val members = remember { groupData?.let { mutableStateOf (it.members) } }
+  val nameState = remember { mutableStateOf(groupData?.name ?: "") }
+  val members = remember { groupData?.let { mutableStateOf(it.members) } }
 
-    groupData?.let {
-        nameState.value = it.name
-        if (members != null) {
-            members.value = it.members
-        }
-    }
-
-    val userDatas = remember { mutableStateOf(mutableListOf<User>()) }
-
+  groupData?.let {
+    nameState.value = it.name
     if (members != null) {
-        for (member in members.value) {
-            groupViewModel.fetchUserData(member)
-            val userData by groupViewModel.member.observeAsState()
-            userData?.let { userDatas.value.add(it) }
-        }
+      members.value = it.members
     }
+  }
 
-    Scaffold(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(White)
-            .testTag("members_scaffold"),
-        topBar = {
-            TopNavigationBar(
-                title = { Sub_title("Members") },
-                navigationIcon = {
-                    GoBackRouteButton(navigationActions = navigationActions, Route.GROUPSHOME)
-                },
-                actions = { GroupsSettingsButton(groupUID, navigationActions, db) })
-        }) { paddingValues ->
+  val userDatas = remember { mutableStateOf(mutableListOf<User>()) }
+
+  if (members != null) {
+    for (member in members.value) {
+      groupViewModel.fetchUserData(member)
+      val userData by groupViewModel.member.observeAsState()
+      userData?.let { userDatas.value.add(it) }
+    }
+  }
+
+  Scaffold(
+      modifier = Modifier.fillMaxSize().background(White).testTag("members_scaffold"),
+      topBar = {
+        TopNavigationBar(
+            title = { Sub_title(stringResource(R.string.members)) },
+            navigationIcon = {
+              GoBackRouteButton(navigationActions = navigationActions, Route.GROUPSHOME)
+            },
+            actions = { GroupsSettingsButton(groupUID, navigationActions, db) })
+      }) { paddingValues ->
         Column(
             modifier = Modifier.fillMaxSize(),
             horizontalAlignment = Alignment.Start,
             verticalArrangement = Arrangement.Top) {
-            LazyColumn(
-                modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
-                    .testTag("draw_member_column"),
-                verticalArrangement = Arrangement.spacedBy(5.dp, Alignment.Top),
-                horizontalAlignment = Alignment.CenterHorizontally) {
-                item { Spacer(modifier = Modifier.padding(10.dp)) }
-                item { Name(nameState) }
-                item { Spacer(modifier = Modifier.padding(10.dp)) }
-                if (members != null) {
-                    items(userDatas.value) { member -> MemberItem(groupUID, member, navigationActions, db) }
-                } else { // Should never happen
-                    item {
+              LazyColumn(
+                  modifier =
+                      Modifier.fillMaxSize().padding(paddingValues).testTag("draw_member_column"),
+                  verticalArrangement = Arrangement.spacedBy(5.dp, Alignment.Top),
+                  horizontalAlignment = Alignment.CenterHorizontally) {
+                    item { Spacer(modifier = Modifier.padding(10.dp)) }
+                    item { Name(nameState) }
+                    item { Spacer(modifier = Modifier.padding(10.dp)) }
+                    if (members != null) {
+                      items(userDatas.value) { member ->
+                        MemberItem(groupUID, member, navigationActions, db)
+                      }
+                    } else { // Should never happen
+                      item {
                         Text(
-                            "Error, no member found for this group",
+                            stringResource(R.string.error_no_member_found_for_this_group),
                             textAlign = TextAlign.Center,
                             modifier = Modifier.testTag("EmptyGroupMemberText"))
+                      }
                     }
-                }
-                //item { add member button } will be added later
-                }
+                    // item { add member button } will be added later
+                  }
             }
-        }
-    }
+      }
+}
 
 @Composable
 fun Name(nameState: MutableState<String>) {
-    Spacer(Modifier.height(20.dp))
-    Text(
-        nameState.value,
-        textAlign = TextAlign.Center,
-        modifier = Modifier.testTag("ShowGroupNameInGroupMember"))
+  Spacer(Modifier.height(20.dp))
+  Text(
+      nameState.value,
+      textAlign = TextAlign.Center,
+      modifier = Modifier.testTag("ShowGroupNameInGroupMember"))
 }
 
 @Composable
-fun MemberItem(groupUID: String, user: User, navigationActions: NavigationActions, db: DbRepository) {
-    Box(
-        modifier =
-        Modifier
-            .fillMaxWidth()
-            .background(Color.White)
-            .drawBehind {
+fun MemberItem(
+    groupUID: String,
+    user: User,
+    navigationActions: NavigationActions,
+    db: DbRepository
+) {
+  Box(
+      modifier =
+          Modifier.fillMaxWidth()
+              .background(Color.White)
+              .drawBehind {
                 val strokeWidth = 1f
                 val y = size.height - strokeWidth / 2
                 drawLine(Color.LightGray, Offset(0f, y), Offset(size.width, y), strokeWidth)
-            }
-            .testTag(user.username + "_box")) {
-        Row(modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp)) {
-            Box(modifier = Modifier
-                .size(52.dp)
-                .clip(CircleShape)
-                .background(Color.Transparent)) {
-                Image(
-                    painter = rememberImagePainter(user.photoUrl),
-                    contentDescription = stringResource(id = R.string.user_picture),
-                    modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Crop)
-            }
-            Spacer(modifier = Modifier.size(16.dp))
-            Text(
-                text = user.username,
-                modifier = Modifier.align(Alignment.CenterVertically),
-                style = TextStyle(fontSize = 20.sp),
-                lineHeight = 28.sp)
-            Spacer(modifier = Modifier.weight(1f))
-            MemberOptionButton(groupUID, user.uid, user.username, navigationActions, db)
+              }
+              .testTag(user.username + "_box")) {
+        Row(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+          Box(modifier = Modifier.size(52.dp).clip(CircleShape).background(Color.Transparent)) {
+            Image(
+                painter = rememberImagePainter(user.photoUrl),
+                contentDescription = stringResource(id = R.string.user_picture),
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop)
+          }
+          Spacer(modifier = Modifier.size(16.dp))
+          Text(
+              text = user.username,
+              modifier = Modifier.align(Alignment.CenterVertically),
+              style = TextStyle(fontSize = 20.sp),
+              lineHeight = 28.sp)
+          Spacer(modifier = Modifier.weight(1f))
+          MemberOptionButton(groupUID, user.uid, user.username, navigationActions, db)
         }
-    }
+      }
 }
 
 @Composable
-fun MemberOptionButton(groupUID: String, userUID: String, username: String, navigationActions: NavigationActions, db: DbRepository) {
-    var isRemoveUserDialogVisible by remember { mutableStateOf(false) }
-    val expandedState = remember { mutableStateOf(false) }
-    val groupViewModel = GroupViewModel(groupUID, db)
-    Row {
-        IconButton(
-            onClick = { expandedState.value = true },
-        ) {
-            Icon(
-                imageVector = Icons.Default.MoreVert,
-                tint = Blue,
-                contentDescription = stringResource(R.string.dots_menu))
-        }
-        DropdownMenu(
-            expanded = expandedState.value,
-            onDismissRequest = { expandedState.value = false }) {
-            GROUPS_MEMBERS_DESTINATIONS.forEach { item ->
-                DropdownMenuItem(
-                    onClick = {
-                        expandedState.value = false
-                        when (item.route) {
-                            Route.USERREMOVE -> {
-                                isRemoveUserDialogVisible = true
-                            }
-                        }
-                    }) {
-                    Spacer(modifier = Modifier.size(16.dp))
-                    Text(item.textId)
-                }
-            }
-        }
+fun MemberOptionButton(
+    groupUID: String,
+    userUID: String,
+    username: String,
+    navigationActions: NavigationActions,
+    db: DbRepository
+) {
+  var isRemoveUserDialogVisible by remember { mutableStateOf(false) }
+  val expandedState = remember { mutableStateOf(false) }
+  val groupViewModel = GroupViewModel(groupUID, db)
+  Row {
+    IconButton(
+        onClick = { expandedState.value = true },
+    ) {
+      Icon(
+          imageVector = Icons.Default.MoreVert,
+          tint = Blue,
+          contentDescription = stringResource(R.string.dots_menu))
     }
-    if (isRemoveUserDialogVisible) {
-        Dialog(onDismissRequest = { isRemoveUserDialogVisible = false }) {
-            Box(
-                modifier =
-                Modifier
-                    .width(280.dp)
-                    .height(140.dp)
-                    .clip(RoundedCornerShape(10.dp))
-                    .background(Color.White)) {
-                Column(
-                    modifier = Modifier.padding(16.dp),
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(
-                        text = "Are you sure you want to remove $username from the group ?",
-                        color = Blue)
-                    Spacer(modifier = Modifier.height(20.dp))
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceEvenly) {
+    DropdownMenu(
+        expanded = expandedState.value, onDismissRequest = { expandedState.value = false }) {
+          GROUPS_MEMBERS_DESTINATIONS.forEach { item ->
+            DropdownMenuItem(
+                onClick = {
+                  expandedState.value = false
+                  when (item.route) {
+                    Route.USERREMOVE -> {
+                      isRemoveUserDialogVisible = true
+                    }
+                  }
+                }) {
+                  Spacer(modifier = Modifier.size(16.dp))
+                  Text(item.textId)
+                }
+          }
+        }
+  }
+  if (isRemoveUserDialogVisible) {
+    Dialog(onDismissRequest = { isRemoveUserDialogVisible = false }) {
+      Box(
+          modifier =
+              Modifier.width(280.dp)
+                  .height(140.dp)
+                  .clip(RoundedCornerShape(10.dp))
+                  .background(Color.White)) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally) {
+                  Text(
+                      text = "Are you sure you want to remove $username from the group ?",
+                      color = Blue)
+                  Spacer(modifier = Modifier.height(20.dp))
+                  Row(
+                      modifier = Modifier.fillMaxWidth(),
+                      horizontalArrangement = Arrangement.SpaceEvenly) {
                         Button(
                             onClick = {
-                                groupViewModel.leaveGroup(groupUID, userUID)
-                                navigationActions.navigateTo("${Route.GROUPMEMBERS}/$groupUID")
-                                isRemoveUserDialogVisible = false
+                              groupViewModel.leaveGroup(groupUID, userUID)
+                              navigationActions.navigateTo("${Route.GROUPMEMBERS}/$groupUID")
+                              isRemoveUserDialogVisible = false
                             },
                             modifier =
-                            Modifier
-                                .clip(RoundedCornerShape(4.dp))
-                                .width(80.dp)
-                                .height(40.dp),
+                                Modifier.clip(RoundedCornerShape(4.dp)).width(80.dp).height(40.dp),
                             colors =
-                            ButtonDefaults.buttonColors(
-                                containerColor = Color.Red, contentColor = White)) {
-                            Text(text = stringResource(R.string.yes))
-                        }
+                                ButtonDefaults.buttonColors(
+                                    containerColor = Color.Red, contentColor = White)) {
+                              Text(text = stringResource(R.string.yes))
+                            }
 
                         Button(
                             onClick = { isRemoveUserDialogVisible = false },
                             modifier =
-                            Modifier
-                                .clip(RoundedCornerShape(4.dp))
-                                .width(80.dp)
-                                .height(40.dp),
+                                Modifier.clip(RoundedCornerShape(4.dp)).width(80.dp).height(40.dp),
                             colors =
-                            ButtonDefaults.buttonColors(
-                                containerColor = Blue, contentColor = White)) {
-                            Text(text = stringResource(R.string.no))
-                        }
-                    }
+                                ButtonDefaults.buttonColors(
+                                    containerColor = Blue, contentColor = White)) {
+                              Text(text = stringResource(R.string.no))
+                            }
+                      }
                 }
-            }
-        }
+          }
     }
+  }
 }

--- a/app/src/main/java/com/github/se/studybuddies/ui/groups/GroupMembers.kt
+++ b/app/src/main/java/com/github/se/studybuddies/ui/groups/GroupMembers.kt
@@ -3,41 +3,90 @@ package com.github.se.studybuddies.ui.groups
 import android.annotation.SuppressLint
 import android.net.Uri
 import android.os.Build
+import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import coil.compose.rememberImagePainter
 import com.github.se.studybuddies.R
+import com.github.se.studybuddies.data.Group
+import com.github.se.studybuddies.data.User
 import com.github.se.studybuddies.database.DbRepository
+import com.github.se.studybuddies.navigation.GROUPS_MEMBERS_DESTINATIONS
+import com.github.se.studybuddies.navigation.GROUPS_SETTINGS_DESTINATIONS
 import com.github.se.studybuddies.navigation.NavigationActions
 import com.github.se.studybuddies.navigation.Route
 import com.github.se.studybuddies.permissions.checkPermission
 import com.github.se.studybuddies.permissions.imagePermissionVersion
 import com.github.se.studybuddies.ui.shared_elements.GoBackRouteButton
+import com.github.se.studybuddies.ui.shared_elements.MainScreenScaffold
 import com.github.se.studybuddies.ui.shared_elements.SaveButton
+import com.github.se.studybuddies.ui.shared_elements.SearchIcon
 import com.github.se.studybuddies.ui.shared_elements.Sub_title
 import com.github.se.studybuddies.ui.shared_elements.TopNavigationBar
+import com.github.se.studybuddies.ui.theme.Blue
 import com.github.se.studybuddies.ui.theme.White
 import com.github.se.studybuddies.viewModels.GroupViewModel
+import com.github.se.studybuddies.viewModels.GroupsHomeViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
-@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter", "MutableCollectionMutableState")
 @Composable
 fun GroupMembers(
     groupUID: String,
@@ -51,17 +100,30 @@ fun GroupMembers(
     val groupData by groupViewModel.group.observeAsState()
 
     val nameState = remember { mutableStateOf(groupData?.name ?: "") }
-    val members = remember { mutableStateOf (???) }
-
-    val context = LocalContext.current
+    val members = remember { groupData?.let { mutableStateOf (it.members) } }
 
     groupData?.let {
         nameState.value = it.name
-        members.value = ???
+        if (members != null) {
+            members.value = it.members
+        }
+    }
+
+    val userDatas = remember { mutableStateOf(mutableListOf<User>()) }
+
+    if (members != null) {
+        for (member in members.value) {
+            groupViewModel.fetchUserData(member)
+            val userData by groupViewModel.member.observeAsState()
+            userData?.let { userDatas.value.add(it) }
+        }
     }
 
     Scaffold(
-        modifier = Modifier.fillMaxSize().background(White).testTag("members_scaffold"),
+        modifier = Modifier
+            .fillMaxSize()
+            .background(White)
+            .testTag("members_scaffold"),
         topBar = {
             TopNavigationBar(
                 title = { Sub_title("Members") },
@@ -76,12 +138,161 @@ fun GroupMembers(
             verticalArrangement = Arrangement.Top) {
             LazyColumn(
                 modifier =
-                Modifier.fillMaxSize().padding(paddingValues).testTag("draw_member_column"),
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .testTag("draw_member_column"),
                 verticalArrangement = Arrangement.spacedBy(5.dp, Alignment.Top),
                 horizontalAlignment = Alignment.CenterHorizontally) {
                 item { Spacer(modifier = Modifier.padding(10.dp)) }
                 item { Name(nameState) }
                 item { Spacer(modifier = Modifier.padding(10.dp)) }
+                if (members != null) {
+                    items(userDatas.value) { member -> MemberItem(groupUID, member, navigationActions, db) }
+                } else { // Should never happen
+                    item {
+                        Text(
+                            "Error, no member found for this group",
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.testTag("EmptyGroupMemberText"))
+                    }
+                }
+                //item { add member button } will be added later
+                }
+            }
+        }
+    }
+
+@Composable
+fun Name(nameState: MutableState<String>) {
+    Spacer(Modifier.height(20.dp))
+    Text(
+        nameState.value,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.testTag("ShowGroupNameInGroupMember"))
+}
+
+@Composable
+fun MemberItem(groupUID: String, user: User, navigationActions: NavigationActions, db: DbRepository) {
+    Box(
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            .background(Color.White)
+            .drawBehind {
+                val strokeWidth = 1f
+                val y = size.height - strokeWidth / 2
+                drawLine(Color.LightGray, Offset(0f, y), Offset(size.width, y), strokeWidth)
+            }
+            .testTag(user.username + "_box")) {
+        Row(modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)) {
+            Box(modifier = Modifier
+                .size(52.dp)
+                .clip(CircleShape)
+                .background(Color.Transparent)) {
+                Image(
+                    painter = rememberImagePainter(user.photoUrl),
+                    contentDescription = stringResource(id = R.string.user_picture),
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop)
+            }
+            Spacer(modifier = Modifier.size(16.dp))
+            Text(
+                text = user.username,
+                modifier = Modifier.align(Alignment.CenterVertically),
+                style = TextStyle(fontSize = 20.sp),
+                lineHeight = 28.sp)
+            Spacer(modifier = Modifier.weight(1f))
+            MemberOptionButton(groupUID, user.uid, user.username, navigationActions, db)
+        }
+    }
+}
+
+@Composable
+fun MemberOptionButton(groupUID: String, userUID: String, username: String, navigationActions: NavigationActions, db: DbRepository) {
+    var isRemoveUserDialogVisible by remember { mutableStateOf(false) }
+    val expandedState = remember { mutableStateOf(false) }
+    val groupViewModel = GroupViewModel(groupUID, db)
+    Row {
+        IconButton(
+            onClick = { expandedState.value = true },
+        ) {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                tint = Blue,
+                contentDescription = stringResource(R.string.dots_menu))
+        }
+        DropdownMenu(
+            expanded = expandedState.value,
+            onDismissRequest = { expandedState.value = false }) {
+            GROUPS_MEMBERS_DESTINATIONS.forEach { item ->
+                DropdownMenuItem(
+                    onClick = {
+                        expandedState.value = false
+                        when (item.route) {
+                            Route.USERREMOVE -> {
+                                isRemoveUserDialogVisible = true
+                            }
+                        }
+                    }) {
+                    Spacer(modifier = Modifier.size(16.dp))
+                    Text(item.textId)
+                }
+            }
+        }
+    }
+    if (isRemoveUserDialogVisible) {
+        Dialog(onDismissRequest = { isRemoveUserDialogVisible = false }) {
+            Box(
+                modifier =
+                Modifier
+                    .width(280.dp)
+                    .height(140.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(Color.White)) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = "Are you sure you want to remove $username from the group ?",
+                        color = Blue)
+                    Spacer(modifier = Modifier.height(20.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceEvenly) {
+                        Button(
+                            onClick = {
+                                groupViewModel.leaveGroup(groupUID, userUID)
+                                navigationActions.navigateTo("${Route.GROUPMEMBERS}/$groupUID")
+                                isRemoveUserDialogVisible = false
+                            },
+                            modifier =
+                            Modifier
+                                .clip(RoundedCornerShape(4.dp))
+                                .width(80.dp)
+                                .height(40.dp),
+                            colors =
+                            ButtonDefaults.buttonColors(
+                                containerColor = Color.Red, contentColor = White)) {
+                            Text(text = stringResource(R.string.yes))
+                        }
+
+                        Button(
+                            onClick = { isRemoveUserDialogVisible = false },
+                            modifier =
+                            Modifier
+                                .clip(RoundedCornerShape(4.dp))
+                                .width(80.dp)
+                                .height(40.dp),
+                            colors =
+                            ButtonDefaults.buttonColors(
+                                containerColor = Blue, contentColor = White)) {
+                            Text(text = stringResource(R.string.no))
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/github/se/studybuddies/ui/groups/GroupMembers.kt
+++ b/app/src/main/java/com/github/se/studybuddies/ui/groups/GroupMembers.kt
@@ -1,7 +1,5 @@
 package com.github.se.studybuddies.ui.groups
 
-//noinspection UsingMaterialAndMaterial3Libraries
-//noinspection UsingMaterialAndMaterial3Libraries
 import android.annotation.SuppressLint
 import android.util.Log
 import androidx.compose.foundation.Image
@@ -21,14 +19,14 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.DropdownMenuItem
-import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -52,7 +50,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
-import coil.compose.rememberImagePainter
+import coil.compose.rememberAsyncImagePainter
 import com.github.se.studybuddies.R
 import com.github.se.studybuddies.data.User
 import com.github.se.studybuddies.database.DbRepository
@@ -174,7 +172,7 @@ fun MemberItem(
         Row(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
           Box(modifier = Modifier.size(52.dp).clip(CircleShape).background(Color.Transparent)) {
             Image(
-                painter = rememberImagePainter(user.photoUrl),
+                painter = rememberAsyncImagePainter(user.photoUrl),
                 contentDescription = stringResource(id = R.string.user_picture),
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop)
@@ -223,10 +221,11 @@ fun MemberOptionButton(
                       isRemoveUserDialogVisible = true
                     }
                   }
-                }) {
+                },
+                text = {
                   Spacer(modifier = Modifier.size(16.dp))
                   Text(item.textId)
-                }
+                })
           }
         }
   }
@@ -252,9 +251,11 @@ fun MemberOptionButton(
                         Button(
                             onClick = {
                               groupViewModel.leaveGroup(groupUID, userUID)
-                              // navigationActions.navigateTo("${Route.GROUPMEMBERS}/$groupUID")
-                              navigationActions.navigateTo(Route.GROUPSHOME)
-                              isRemoveUserDialogVisible = false
+                              if (membersCount > 1) {
+                                navigationActions.navigateTo("${Route.GROUPMEMBERS}/$groupUID")
+                              } else {
+                                navigationActions.navigateTo(Route.GROUPSHOME)
+                              }
                             },
                             modifier =
                                 Modifier.clip(RoundedCornerShape(5.dp)).width(80.dp).height(40.dp),

--- a/app/src/main/java/com/github/se/studybuddies/ui/groups/GroupMembers.kt
+++ b/app/src/main/java/com/github/se/studybuddies/ui/groups/GroupMembers.kt
@@ -117,31 +117,30 @@ fun GroupMembers(
       }) { paddingValues ->
         Column(
             modifier = Modifier.fillMaxSize(),
-            horizontalAlignment = Alignment.Start,
-            verticalArrangement = Arrangement.Top) {
-              LazyColumn(
-                  modifier =
-                      Modifier.fillMaxSize().padding(paddingValues).testTag("draw_member_column"),
-                  verticalArrangement = Arrangement.spacedBy(5.dp, Alignment.Top),
-                  horizontalAlignment = Alignment.CenterHorizontally) {
-                    item { Spacer(modifier = Modifier.padding(10.dp)) }
-                    item { Name(nameState) }
-                    item { Spacer(modifier = Modifier.padding(10.dp)) }
-                    if (members != null) {
-                      items(userDatas.value) { member ->
-                        MemberItem(groupUID, member, navigationActions, db, userDatas.value.size)
-                      }
-                    } else { // Should never happen
-                      item {
-                        Text(
-                            stringResource(R.string.error_no_member_found_for_this_group),
-                            textAlign = TextAlign.Center,
-                            modifier = Modifier.testTag("EmptyGroupMemberText"))
-                      }
-                    }
-                    // item { add member button } will be added later
+            verticalArrangement = Arrangement.Top,
+        ) {
+          LazyColumn(
+              modifier =
+                  Modifier.fillMaxSize().padding(paddingValues).testTag("draw_member_column"),
+              verticalArrangement = Arrangement.spacedBy(5.dp, Alignment.Top),
+              horizontalAlignment = Alignment.CenterHorizontally) {
+                item { Name(nameState) }
+                item { Spacer(modifier = Modifier.padding(5.dp)) }
+                if (members != null) {
+                  items(userDatas.value) { member ->
+                    MemberItem(groupUID, member, navigationActions, db, userDatas.value.size)
                   }
-            }
+                } else { // Should never happen
+                  item {
+                    Text(
+                        stringResource(R.string.error_no_member_found_for_this_group),
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.testTag("EmptyGroupMemberText"))
+                  }
+                }
+                // item { add member button } will be added later
+              }
+        }
       }
 }
 

--- a/app/src/main/java/com/github/se/studybuddies/ui/groups/GroupMembers.kt
+++ b/app/src/main/java/com/github/se/studybuddies/ui/groups/GroupMembers.kt
@@ -1,5 +1,7 @@
 package com.github.se.studybuddies.ui.groups
 
+//noinspection UsingMaterialAndMaterial3Libraries
+//noinspection UsingMaterialAndMaterial3Libraries
 import android.annotation.SuppressLint
 import android.util.Log
 import androidx.compose.foundation.Image
@@ -251,17 +253,12 @@ fun MemberOptionButton(
                         Button(
                             onClick = {
                               groupViewModel.leaveGroup(groupUID, userUID)
-                              if (membersCount > 1) {
-                                navigationActions.navigateTo(
-                                    Route.GROUPSHOME) // To show the member has left
-                                // navigationActions.navigateTo("${Route.GROUPMEMBERS}/$groupUID")
-                              } else {
-                                navigationActions.navigateTo(Route.GROUPSHOME)
-                              }
+                              // navigationActions.navigateTo("${Route.GROUPMEMBERS}/$groupUID")
+                              navigationActions.navigateTo(Route.GROUPSHOME)
                               isRemoveUserDialogVisible = false
                             },
                             modifier =
-                                Modifier.clip(RoundedCornerShape(4.dp)).width(80.dp).height(40.dp),
+                                Modifier.clip(RoundedCornerShape(5.dp)).width(80.dp).height(40.dp),
                             colors =
                                 ButtonDefaults.buttonColors(
                                     containerColor = Color.Red, contentColor = White)) {
@@ -271,7 +268,7 @@ fun MemberOptionButton(
                         Button(
                             onClick = { isRemoveUserDialogVisible = false },
                             modifier =
-                                Modifier.clip(RoundedCornerShape(4.dp)).width(80.dp).height(40.dp),
+                                Modifier.clip(RoundedCornerShape(5.dp)).width(80.dp).height(40.dp),
                             colors =
                                 ButtonDefaults.buttonColors(
                                     containerColor = Blue, contentColor = White)) {

--- a/app/src/main/java/com/github/se/studybuddies/viewModels/GroupViewModel.kt
+++ b/app/src/main/java/com/github/se/studybuddies/viewModels/GroupViewModel.kt
@@ -21,7 +21,9 @@ class GroupViewModel(uid: String? = null, private val db: DbRepository = Databas
     ViewModel() {
   private val _group = MutableLiveData(Group.empty())
   private val _members = MutableLiveData<List<User>>(emptyList())
+  private val _member = MutableLiveData(User.empty())
   val members: LiveData<List<User>> = _members
+  val member: LiveData<User> = _member
   val group: LiveData<Group> = _group
   private val _topics = MutableStateFlow(TopicList(emptyList()))
   val topics = _topics.asStateFlow()
@@ -36,6 +38,10 @@ class GroupViewModel(uid: String? = null, private val db: DbRepository = Databas
 
   fun fetchGroupData(uid: String) {
     viewModelScope.launch { _group.value = db.getGroup(uid) }
+  }
+
+  fun fetchUserData(uid: String) {
+    viewModelScope.launch { _member.value = db.getUser(uid) }
   }
 
   private fun subscribeToTopics(uid: String) {

--- a/app/src/main/java/com/github/se/studybuddies/viewModels/GroupViewModel.kt
+++ b/app/src/main/java/com/github/se/studybuddies/viewModels/GroupViewModel.kt
@@ -44,6 +44,10 @@ class GroupViewModel(uid: String? = null, private val db: DbRepository = Databas
     viewModelScope.launch { _member.value = db.getUser(uid) }
   }
 
+  fun getCurrentUser(): String {
+    return db.getCurrentUserUID()
+  }
+
   private fun subscribeToTopics(uid: String) {
     db.getAllTopics(uid, viewModelScope, Dispatchers.IO, Dispatchers.Main) { topicList ->
       _topics.value = topicList

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="map">Map</string>
     <string name="group_option">Group Option</string>
     <string name="group_picture">Group picture</string>
+    <string name="user_picture">User picture</string>
     <string name="in_group_with_uid">In group %1$s with uid %2$s</string>
     <string name="join_or_create_a_new_group">Join or create a new group</string>
     <string name="dots_menu">Dots Menu</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,4 +116,6 @@
     <string name="hour">Hour</string>
     <string name="minute">Minute</string>
     <string name="ok">OK</string>
+    <string name="members">Members</string>
+    <string name="error_no_member_found_for_this_group">Error, no member found for this group</string>
 </resources>


### PR DESCRIPTION
Add a button so that you can see all members actually in a group using the HameburgerMenu, including picture and name of each user

On this page you can see all members and with another HameburgerMenu you can remove each user of the group

Add the goBack button, name of the group, menu to modifyGroup and so on

Add a confirmation panel to be sure you want to remove that user and that you choose the good one (display his name)
