### PR TITLE
CI scroll bug fix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ name: CI - Test Runner
 on:
   push:
     branches:
-      - '**'
+      - main
 
   pull_request:
     types:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ name: CI - Test Runner
 on:
   push:
     branches:
-      - main
+      - '**'
 
   pull_request:
     types:

--- a/app/src/androidTest/java/com/github/se/studybuddies/endToEndTests/GroupCreateJoin.kt
+++ b/app/src/androidTest/java/com/github/se/studybuddies/endToEndTests/GroupCreateJoin.kt
@@ -2,11 +2,12 @@ package com.github.se.studybuddies.endToEndTests
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.printToLog
@@ -51,7 +52,11 @@ class GroupCreateJoin : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
     // composeTestRule.waitForIdle()
     // Espresso.closeSoftKeyboard()
     // composeTestRule.waitForIdle()
-    composeTestRule.onNodeWithTag("save_button_account").performScrollTo().performClick()
+    // composeTestRule.onNodeWithTag("save_button_account").performScrollTo().performClick()
+    composeTestRule
+        .onNodeWithTag("content")
+        .performScrollToNode(hasTestTag("save_button_account"))
+        .performClick()
 
     val a = 1
     /*

--- a/app/src/androidTest/java/com/github/se/studybuddies/endToEndTests/GroupCreateJoin.kt
+++ b/app/src/androidTest/java/com/github/se/studybuddies/endToEndTests/GroupCreateJoin.kt
@@ -2,14 +2,14 @@ package com.github.se.studybuddies.endToEndTests
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.printToLog
 import androidx.test.core.app.ActivityScenario
-import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.studybuddies.testUtilities.MockMainActivity
 import com.kaspersky.components.composesupport.config.withComposeSupport
@@ -32,27 +32,30 @@ class GroupCreateJoin : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
     ActivityScenario.launch(MockMainActivity::class.java)
   }
 
+  private fun printNodeTree(loc: String = "") {
+    composeTestRule
+        .onAllNodes(isRoot(), useUnmergedTree = true)
+        .printToLog("Print root @${loc} : ", maxDepth = 10)
+  }
+
   @Test
   fun userFlow1() {
     composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("username_field").assertIsDisplayed().performTextClearance()
+    printNodeTree("before username input")
+    composeTestRule.onNodeWithTag("username_field").performTextInput("test user")
+    printNodeTree("after username input")
+    composeTestRule.onNodeWithTag("username_field").assertTextContains("test user")
+    // composeTestRule.waitForIdle()
+    // Espresso.closeSoftKeyboard()
+    // composeTestRule.waitForIdle()
     composeTestRule
-        .onNodeWithTag("username_field", useUnmergedTree = true)
-        .assertIsDisplayed()
-        .performTextClearance()
-    composeTestRule
-        .onNodeWithTag("username_field", useUnmergedTree = true)
-        .performTextInput("test user")
-    composeTestRule
-        .onNodeWithTag("username_field", useUnmergedTree = true)
-        .assertTextContains("test user")
-    composeTestRule.waitForIdle()
-    Espresso.closeSoftKeyboard()
-    composeTestRule.waitForIdle()
-    composeTestRule
-        .onNodeWithTag("save_button_account", useUnmergedTree = true)
-        .performScrollTo()
+        .onNodeWithTag("save_button_account")
+        // .performScrollTo()
         .performClick()
 
+    val a = 1
     /*
     @Test
     fun userFlow1() {

--- a/app/src/androidTest/java/com/github/se/studybuddies/endToEndTests/GroupCreateJoin.kt
+++ b/app/src/androidTest/java/com/github/se/studybuddies/endToEndTests/GroupCreateJoin.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.printToLog
@@ -50,10 +51,7 @@ class GroupCreateJoin : TestCase(kaspressoBuilder = Kaspresso.Builder.withCompos
     // composeTestRule.waitForIdle()
     // Espresso.closeSoftKeyboard()
     // composeTestRule.waitForIdle()
-    composeTestRule
-        .onNodeWithTag("save_button_account")
-        // .performScrollTo()
-        .performClick()
+    composeTestRule.onNodeWithTag("save_button_account").performScrollTo().performClick()
 
     val a = 1
     /*

--- a/app/src/main/java/com/github/se/studybuddies/testUtilities/MockMainActivity.kt
+++ b/app/src/main/java/com/github/se/studybuddies/testUtilities/MockMainActivity.kt
@@ -5,17 +5,17 @@ import com.github.se.studybuddies.MainActivity
 import com.github.se.studybuddies.database.MockDatabase
 
 class MockMainActivity : MainActivity() {
+  private val fakeUid: String = "E2EUserTest"
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    val fakeUID = "E2EUserTest"
     db = MockDatabase()
-    startApp(fakeUID, db)
+    startApp(fakeUid, db)
   }
 
   override fun onStop() {
     super.onStop()
-    val fakeUID = "E2EUserTest"
     db = MockDatabase()
-    offlineLocation(fakeUID, db)
+    offlineLocation(fakeUid, db)
   }
 }


### PR DESCRIPTION
`performScrollTo` should be used **on the lazy column** instead of the node itself. I would suggest @Ovoland to rename the test tag for the lazy column. It is currently called "content"